### PR TITLE
fix(release): remove nonexistent --features wasm flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build WASM module
         run: |
-          wasm-pack build --target bundler --out-dir web/wasm --release -- --features wasm
+          wasm-pack build --target bundler --out-dir web/wasm --release
 
       - name: Install npm dependencies
         working-directory: web


### PR DESCRIPTION
The crate uses `cfg(target_arch = "wasm32")` for WASM gating — there is no `[features]` section in `Cargo.toml` and no `wasm` feature exists. The `-- --features wasm` flag passed to `wasm-pack build` was causing the build to fail with:

```
error: the package 'poker-odds' does not contain this feature: wasm
```

Fix: remove the flag, matching the `make wasm` command exactly.