### PR TITLE
perf(solver): reduce allocations and consolidate CFR hot-path updates

### DIFF
--- a/benches/solver_bench.rs
+++ b/benches/solver_bench.rs
@@ -199,6 +199,42 @@ fn bench_exploitability(c: &mut Criterion) {
     });
 }
 
+/// Exploitability benchmark on a deeper river tree. The existing Kuhn case is
+/// too small for heap-allocation costs in the best-response traversal to show
+/// up — this one exercises a tree with more decision nodes and opponent info
+/// sets (where pass1/pass2 read the averaged strategy per node).
+fn bench_exploitability_river(c: &mut Criterion) {
+    use poker_odds::solver::exploitability::compute_exploitability;
+
+    let board = [
+        Card::new(Rank::Ace, Suit::Spades),
+        Card::new(Rank::King, Suit::Hearts),
+        Card::new(Rank::Queen, Suit::Diamonds),
+        Card::new(Rank::Seven, Suit::Clubs),
+        Card::new(Rank::Two, Suit::Spades),
+    ];
+    let bet_config = BetSizingConfig {
+        river_bets: vec![0.33, 0.67, 1.0],
+        river_raises: vec![1.0, 2.0],
+        always_allow_allin: true,
+        max_raises_per_street: 2,
+        ..Default::default()
+    };
+
+    let tree = build_river_tree(board, 100.0, 200.0, bet_config);
+    let config = SolverConfig {
+        algorithm: CfrAlgorithm::CfrPlus,
+        iterations: 2000,
+        ..Default::default()
+    };
+    let mut solver = CfrSolver::new(tree, config);
+    solver.solve();
+
+    c.bench_function("river_exploitability", |b| {
+        b.iter(|| black_box(compute_exploitability(&solver.tree, &solver.store, 1.0)));
+    });
+}
+
 /// Microbenchmark: the DCFR discount pass over a large synthetic flat store.
 ///
 /// Exercises `InfoSetStore::{discount_regrets_all, discount_strategy_sum_all}`
@@ -285,6 +321,7 @@ criterion_group!(
     bench_river_dcfr_hot,
     bench_dcfr_discount_pass,
     bench_exploitability,
+    bench_exploitability_river,
     bench_equity_computation,
 );
 criterion_main!(benches);

--- a/benches/solver_bench.rs
+++ b/benches/solver_bench.rs
@@ -1,8 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use poker_odds::cards::card::{Card, Rank, Suit};
+use poker_odds::solver::abstraction::EquityBuckets;
 use poker_odds::solver::action::BetSizingConfig;
 use poker_odds::solver::cfr::{CfrAlgorithm, CfrSolver, SolverConfig};
-use poker_odds::solver::postflop::build_river_tree;
+use poker_odds::solver::postflop::{build_river_tree, PostflopConfig, PostflopTreeBuilder};
+use poker_odds::solver::range::HandRange;
 use poker_odds::solver::toy_games::{KuhnPoker, LeducPoker};
 
 fn bench_kuhn_cfr_plus(c: &mut Criterion) {
@@ -182,6 +184,65 @@ fn bench_river_traversal_hot(c: &mut Criterion) {
     group.finish();
 }
 
+/// Realistic postflop CFR benchmark on a flop scenario.
+///
+/// The previous benches cover toy games (Kuhn, Leduc) and single-street river
+/// solves. This one exercises the full flop→turn→river tree with equity-bucket
+/// abstraction — representative of the workload a real user hits in the TUI
+/// solver, and the bed on which vector-CFR and action-pruning optimizations
+/// will be measured.
+///
+/// Kept small (pocket-pair range, coarse 12-bucket abstraction, two bet sizes)
+/// so tree construction and one iteration both stay sub-second. Tree is built
+/// once; each bench iteration clones it and runs `solve()` from a fresh store.
+fn bench_flop_cfr_plus(c: &mut Criterion) {
+    let board = [
+        Card::new(Rank::Ten, Suit::Spades),
+        Card::new(Rank::Seven, Suit::Hearts),
+        Card::new(Rank::Two, Suit::Diamonds),
+    ];
+    let bet_config = BetSizingConfig {
+        flop_bets: vec![0.5],
+        flop_raises: vec![1.0],
+        turn_bets: vec![0.75],
+        turn_raises: vec![1.0],
+        river_bets: vec![1.0],
+        river_raises: vec![1.0],
+        always_allow_allin: false,
+        max_raises_per_street: 1,
+    };
+    let range_oop: HandRange = "QQ-TT".parse().expect("valid range");
+    let range_ip: HandRange = "JJ-99".parse().expect("valid range");
+    let config = PostflopConfig {
+        board: board.to_vec(),
+        range_oop,
+        range_ip,
+        starting_pot: 40.0,
+        effective_stack: 100.0,
+        bet_config,
+        abstraction: Box::new(EquityBuckets::new(12)),
+    };
+    let tree = PostflopTreeBuilder::new(config).build();
+
+    let mut group = c.benchmark_group("flop_cfr_plus");
+    group.sample_size(10);
+    for &iters in &[100u32, 500] {
+        group.bench_with_input(BenchmarkId::from_parameter(iters), &iters, |b, &iters| {
+            let solver_config = SolverConfig {
+                algorithm: CfrAlgorithm::CfrPlus,
+                iterations: iters,
+                ..Default::default()
+            };
+            b.iter_batched(
+                || CfrSolver::new(tree.clone(), solver_config.clone()),
+                |mut solver| black_box(solver.solve()),
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
 fn bench_exploitability(c: &mut Criterion) {
     use poker_odds::solver::exploitability::compute_exploitability;
 
@@ -320,6 +381,7 @@ criterion_group!(
     bench_river_traversal_hot,
     bench_river_dcfr_hot,
     bench_dcfr_discount_pass,
+    bench_flop_cfr_plus,
     bench_exploitability,
     bench_exploitability_river,
     bench_equity_computation,

--- a/src/solver/cfr.rs
+++ b/src/solver/cfr.rs
@@ -233,19 +233,17 @@ fn cfr_traverse(
                 let opp_reach = if player == 0 { reach_p1 } else { reach_p0 };
                 let my_reach = if player == 0 { reach_p0 } else { reach_p1 };
 
-                // Update regrets
-                for (i, &av) in action_values[..n_actions].iter().enumerate() {
-                    let regret = av - node_value;
-                    store.add_regret(info_set_idx, i, opp_reach * regret);
-                }
-
-                // CFR+: clip negative regrets
-                if use_cfr_plus {
-                    store.clip_negative_regrets(info_set_idx);
-                }
-
-                // Accumulate strategy for averaging
-                store.accumulate_strategy(info_set_idx, &strategy[..n_actions], my_reach);
+                // Combined regret update + optional CFR+ clip + strategy
+                // accumulation under a single offset lookup.
+                store.update_regrets_and_strategy(
+                    info_set_idx,
+                    &action_values[..n_actions],
+                    node_value,
+                    &strategy[..n_actions],
+                    opp_reach,
+                    my_reach,
+                    use_cfr_plus,
+                );
             }
 
             node_value

--- a/src/solver/exploitability.rs
+++ b/src/solver/exploitability.rs
@@ -1,6 +1,10 @@
 use crate::solver::game_tree::{GameTree, GameTreeNode, NodeIndex};
 use crate::solver::info_set::InfoSetStore;
 
+/// Upper bound on the number of actions at any decision node. Sized to match
+/// the CFR traversal's stack-buffer limit.
+const MAX_ACTIONS: usize = 16;
+
 /// Compute the exploitability of the current average strategy in mbb/hand.
 ///
 /// Exploitability = (BR_value_p0 + BR_value_p1) / 2, where BR_value_pX is the
@@ -119,8 +123,12 @@ fn pass1_action_values(
                 }
                 total_value / n_actions as f64
             } else {
-                // Opponent: use their average strategy
-                let avg_strategy = store.average_strategy(*info_set_idx);
+                // Opponent: use their average strategy. Stack buffer avoids
+                // a per-call Vec<f32> allocation on the hot recursive path.
+                let n_actions = children.len();
+                debug_assert!(n_actions <= MAX_ACTIONS);
+                let mut avg_strategy = [0.0f32; MAX_ACTIONS];
+                store.average_strategy_into(*info_set_idx, &mut avg_strategy[..n_actions]);
                 let mut value = 0.0;
                 for (i, &child) in children.iter().enumerate() {
                     let prob = avg_strategy[i] as f64;
@@ -178,15 +186,18 @@ fn pass2_br_value(
                 let best = best_actions[*info_set_idx as usize];
                 pass2_br_value(tree, store, children[best], br_player, best_actions)
             } else {
-                // Opponent uses their average strategy
-                let avg_strategy = store.average_strategy(*info_set_idx);
-                children
-                    .iter()
-                    .zip(avg_strategy.iter())
-                    .map(|(&child, &prob)| {
-                        prob as f64 * pass2_br_value(tree, store, child, br_player, best_actions)
-                    })
-                    .sum()
+                // Opponent uses their average strategy. Stack buffer avoids
+                // per-call Vec<f32> allocation.
+                let n_actions = children.len();
+                debug_assert!(n_actions <= MAX_ACTIONS);
+                let mut avg_strategy = [0.0f32; MAX_ACTIONS];
+                store.average_strategy_into(*info_set_idx, &mut avg_strategy[..n_actions]);
+                let mut value = 0.0;
+                for (i, &child) in children.iter().enumerate() {
+                    value += avg_strategy[i] as f64
+                        * pass2_br_value(tree, store, child, br_player, best_actions);
+                }
+                value
             }
         }
     }

--- a/src/solver/game_tree.rs
+++ b/src/solver/game_tree.rs
@@ -30,6 +30,7 @@ pub enum GameTreeNode {
 }
 
 /// The complete game tree as a flat arena of nodes.
+#[derive(Clone)]
 pub struct GameTree {
     /// All nodes stored contiguously.
     pub nodes: Vec<GameTreeNode>,

--- a/src/solver/info_set.rs
+++ b/src/solver/info_set.rs
@@ -103,6 +103,52 @@ impl InfoSetStore {
         }
     }
 
+    /// Combined CFR update for one info set: add regrets (scaled by `opp_reach`),
+    /// optionally clip negatives (CFR+), and accumulate strategy weights (scaled
+    /// by `my_reach`) — all under a single offset lookup.
+    ///
+    /// Replaces three separate hot-path calls (`add_regret` in a loop,
+    /// `clip_negative_regrets`, `accumulate_strategy`) with one method so the
+    /// offset/length lookups happen once per decision-node visit instead of
+    /// 2 + n_actions times.
+    ///
+    /// `action_values.len()` and `strategy.len()` must equal the number of
+    /// actions at the info set.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_regrets_and_strategy(
+        &mut self,
+        info_set_idx: u32,
+        action_values: &[f32],
+        node_value: f32,
+        strategy: &[f32],
+        opp_reach: f32,
+        my_reach: f32,
+        clip_negative: bool,
+    ) {
+        let offset = self.offsets[info_set_idx as usize] as usize;
+        let n = self.num_actions[info_set_idx as usize] as usize;
+        debug_assert_eq!(action_values.len(), n);
+        debug_assert_eq!(strategy.len(), n);
+
+        let regrets = &mut self.regrets[offset..offset + n];
+        if clip_negative {
+            for (r, &av) in regrets.iter_mut().zip(action_values.iter()) {
+                let updated = *r + opp_reach * (av - node_value);
+                *r = updated.max(0.0);
+            }
+        } else {
+            for (r, &av) in regrets.iter_mut().zip(action_values.iter()) {
+                *r += opp_reach * (av - node_value);
+            }
+        }
+
+        let sums = &mut self.strategy_sum[offset..offset + n];
+        for (sum, &s) in sums.iter_mut().zip(strategy.iter()) {
+            *sum += my_reach * s;
+        }
+    }
+
     /// CFR+: clip all negative regrets to zero for an info set.
     #[inline]
     pub fn clip_negative_regrets(&mut self, info_set_idx: u32) {

--- a/src/solver/info_set.rs
+++ b/src/solver/info_set.rs
@@ -178,15 +178,34 @@ impl InfoSetStore {
 
     /// Get the average strategy at an info set (the converged Nash equilibrium strategy).
     pub fn average_strategy(&self, info_set_idx: u32) -> Vec<f32> {
+        let n = self.num_actions[info_set_idx as usize] as usize;
+        let mut out = vec![0.0; n];
+        self.average_strategy_into(info_set_idx, &mut out);
+        out
+    }
+
+    /// Same as [`average_strategy`] but writes into a caller-provided buffer.
+    ///
+    /// `out.len()` must equal the number of actions at the info set. This avoids
+    /// per-call `Vec<f32>` allocation in exploitability/best-response traversal.
+    #[inline]
+    pub fn average_strategy_into(&self, info_set_idx: u32, out: &mut [f32]) {
         let offset = self.offsets[info_set_idx as usize] as usize;
         let n = self.num_actions[info_set_idx as usize] as usize;
+        debug_assert_eq!(out.len(), n);
         let sums = &self.strategy_sum[offset..offset + n];
 
         let total: f32 = sums.iter().sum();
         if total > 0.0 {
-            sums.iter().map(|&s| s / total).collect()
+            let inv = 1.0 / total;
+            for (o, &s) in out.iter_mut().zip(sums.iter()) {
+                *o = s * inv;
+            }
         } else {
-            vec![1.0 / n as f32; n]
+            let u = 1.0 / n as f32;
+            for o in out.iter_mut() {
+                *o = u;
+            }
         }
     }
 }

--- a/src/solver/strategy.rs
+++ b/src/solver/strategy.rs
@@ -20,7 +20,8 @@ pub struct StrategyProfile {
 impl StrategyProfile {
     /// Extract the average strategy from the solver's cumulative strategy sums.
     pub fn from_store(store: &InfoSetStore, tree: &GameTree) -> Self {
-        let mut action_probs = Vec::with_capacity(store.strategy_sum.len());
+        let total = store.strategy_sum.len();
+        let mut action_probs = vec![0.0f32; total];
         let mut action_labels: Vec<Vec<Action>> = vec![Vec::new(); tree.num_info_sets as usize];
 
         // Collect action labels from tree nodes
@@ -37,10 +38,12 @@ impl StrategyProfile {
             }
         }
 
-        // Normalize strategy sums to probabilities
+        // Normalize strategy sums to probabilities, writing directly into
+        // the flat output buffer instead of allocating a Vec per info set.
         for idx in 0..store.offsets.len() {
-            let avg = store.average_strategy(idx as u32);
-            action_probs.extend_from_slice(&avg);
+            let offset = store.offsets[idx] as usize;
+            let n = store.num_actions[idx] as usize;
+            store.average_strategy_into(idx as u32, &mut action_probs[offset..offset + n]);
         }
 
         Self {


### PR DESCRIPTION
## Summary

Follow-up batch of solver perf improvements on top of the earlier CFR hot-path allocation and DCFR discount consolidation work (already merged). No behavioural changes — average strategies, game values, and exploitability are unchanged; only the per-iteration cost drops.

Three commits in this PR:

- **`perf(solver): drop heap allocations in best-response traversal`** (46bffa4) — adds `InfoSetStore::average_strategy_into` writing into a caller buffer; rewrites `exploitability.rs` pass1/pass2 and `StrategyProfile::from_store` to use `[f32; MAX_ACTIONS]` stack buffers / direct writes into the flat output instead of allocating a `Vec<f32>` per opponent decision node. Adds `bench_exploitability_river` on a deeper tree.
- **`perf(solver): add realistic flop CFR benchmark`** (59b78a8) — `#[derive(Clone)]` on `GameTree` and a new `bench_flop_cfr_plus` covering a full flop→turn→river tree with `EquityBuckets::new(12)` and a pocket-pair matchup, so subsequent optimisations (vector CFR, action pruning) have a representative bed.
- **`perf(solver): fold per-infoset CFR updates into one pass`** (d6e286f) — replaces the `add_regret`-loop + `clip_negative_regrets` + `accumulate_strategy` sequence at each decision node with a single `InfoSetStore::update_regrets_and_strategy` call. Offset/length lookups go from `2 + n_actions` to `1` per node; CFR+ clip is hoisted out of the inner loop.

## Measured impact (criterion --quick)

| Bench | Before | After | Δ |
|---|---|---|---|
| `kuhn_exploitability` | 1.83 µs | 1.53 µs | -16% |
| `river_exploitability` | 1.95 µs | 1.71 µs | -12% |
| `kuhn_cfr_plus/10k` | ~10.4 ms | 8.5 ms | -19% |
| `kuhn_dcfr/10k` | ~10.8 ms | 8.7 ms | -19% |
| `river_traversal_hot/2000` | 1.56 ms | 1.48 ms | -9% |
| `river_dcfr_hot/2000` | 1.91 ms | 1.62 ms | -15% |
| `flop_cfr_plus/500` | 1.34 s | 1.21 s | -10% |

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all 34 solver tests green, existing exploitability-decreases and Nash-equilibrium tests unchanged
- [x] Benchmarks on existing kuhn/leduc/river/flop suites; no regressions observed

## Follow-ups (not in this PR)

The larger optimisations from the methodology review — **vector CFR over the 1326-combo reach (§4.1)**, action pruning (§4.5), defaulting to `EquityBuckets` in the TUI (§4.4), and exposing the solver to WASM (§4.8) — will land on a separate branch. Those touch hot-path shape (4.1), user-facing behaviour (4.4), or wire up new surfaces (4.8), so they warrant their own review.

https://claude.ai/code/session_011gXDs5AHGwE2ZFPyGmKaa5