### PR TITLE
feat(solver): flop vector builder, rayon parallelism, WASM bindings

### DIFF
--- a/benches/solver_bench.rs
+++ b/benches/solver_bench.rs
@@ -603,6 +603,95 @@ fn bench_river_scalar_vs_vector(c: &mut Criterion) {
     group.finish();
 }
 
+/// Full-range fair comparison: vector CFR carries ~1326 combos through
+/// every node per iteration, so the matched workload for scalar CFR is
+/// to traverse the same tree `N_COMBOS` times (one per combo).
+///
+/// The bench measures total time for:
+/// - **scalar_fullrange**: `iters * N_COMBOS` scalar CFR+ iterations on the
+///   same river tree — a per-combo traversal budget equivalent to the
+///   vector solver's per-combo work at the root.
+/// - **vector**: `iters` vector CFR+ iterations on the same scenario with
+///   unit-weight ranges for both players.
+///
+/// With this scaling, the comparison reflects the real claim: vector CFR
+/// pays a per-node vector cost but eliminates the per-combo outer loop.
+/// Toy bet configs and small `iters` keep the bench tractable, since
+/// `iters * N_COMBOS` grows very fast on deeper trees.
+fn bench_river_full_range_vs_vector(c: &mut Criterion) {
+    use poker_odds::solver::showdown::N_COMBOS;
+    use poker_odds::solver::vector_cfr::VectorCfrSolver;
+    use poker_odds::solver::vector_postflop::build_vector_river_tree;
+
+    let board = [
+        Card::new(Rank::Ace, Suit::Spades),
+        Card::new(Rank::King, Suit::Hearts),
+        Card::new(Rank::Queen, Suit::Diamonds),
+        Card::new(Rank::Seven, Suit::Clubs),
+        Card::new(Rank::Two, Suit::Spades),
+    ];
+    // Keep action sizing minimal — the scalar arm runs `iters * N_COMBOS`
+    // traversals, which blows up on deeper trees.
+    let bet_config = BetSizingConfig {
+        river_bets: vec![1.0],
+        river_raises: vec![],
+        always_allow_allin: false,
+        max_raises_per_street: 0,
+        ..Default::default()
+    };
+
+    let mut group = c.benchmark_group("river_full_range_vs_vector");
+    group.sample_size(10);
+
+    for &iters in &[1u32, 5] {
+        let scalar_iters = iters * N_COMBOS as u32;
+        group.bench_with_input(
+            BenchmarkId::new("scalar_fullrange", iters),
+            &scalar_iters,
+            |b, &scalar_iters| {
+                b.iter_batched(
+                    || {
+                        let tree = build_river_tree(board, 100.0, 200.0, bet_config.clone());
+                        let config = SolverConfig {
+                            algorithm: CfrAlgorithm::CfrPlus,
+                            iterations: scalar_iters,
+                            ..Default::default()
+                        };
+                        CfrSolver::new(tree, config)
+                    },
+                    |mut solver| black_box(solver.solve()),
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+
+        group.bench_with_input(BenchmarkId::new("vector", iters), &iters, |b, &iters| {
+            b.iter_batched(
+                || {
+                    let tree = build_vector_river_tree(board, 100.0, 200.0, bet_config.clone());
+                    let mut r0 = Box::new([0.0f32; N_COMBOS]);
+                    let mut r1 = Box::new([0.0f32; N_COMBOS]);
+                    for i in 0..N_COMBOS {
+                        if !tree.rankers[0].is_blocked(i as u16) {
+                            r0[i] = 1.0;
+                            r1[i] = 1.0;
+                        }
+                    }
+                    let config = SolverConfig {
+                        algorithm: CfrAlgorithm::CfrPlus,
+                        iterations: iters,
+                        ..Default::default()
+                    };
+                    VectorCfrSolver::new(tree, r0, r1, config)
+                },
+                |mut solver| black_box(solver.solve()),
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_kuhn_cfr_plus,
@@ -619,5 +708,6 @@ criterion_group!(
     bench_showdown,
     bench_vector_info_set,
     bench_river_scalar_vs_vector,
+    bench_river_full_range_vs_vector,
 );
 criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,6 @@ pub mod cards;
 pub mod eval;
 pub mod game;
 pub mod sim;
-
-#[cfg(not(target_arch = "wasm32"))]
 pub mod solver;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/src/sim/config.rs
+++ b/src/sim/config.rs
@@ -27,20 +27,19 @@ impl Default for SimConfig {
 }
 
 impl SimConfig {
+    #[cfg(target_arch = "wasm32")]
     pub fn effective_threads(&self) -> usize {
-        #[cfg(target_arch = "wasm32")]
-        {
-            return 1;
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            if self.threads == 0 {
-                std::thread::available_parallelism()
-                    .map(|n| n.get())
-                    .unwrap_or(4)
-            } else {
-                self.threads
-            }
+        1
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn effective_threads(&self) -> usize {
+        if self.threads == 0 {
+            std::thread::available_parallelism()
+                .map(|n| n.get())
+                .unwrap_or(4)
+        } else {
+            self.threads
         }
     }
 }

--- a/src/solver/info_set.rs
+++ b/src/solver/info_set.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
 
 /// Below this total flat-array length, the bulk DCFR discount operations run
@@ -6,7 +7,9 @@ use rayon::prelude::*;
 /// are much larger than L3 cache. On a 16-core box the empirical crossover
 /// lives near 1–2M f32 elements; this threshold is chosen to keep Kuhn, Leduc,
 /// and typical river postflop trees on the serial path while still firing on
-/// million-info-set solves.
+/// million-info-set solves. On wasm32 the threshold is ignored: the browser
+/// runs in a single worker thread, so the parallel branch is never taken.
+#[cfg(not(target_arch = "wasm32"))]
 const PARALLEL_DISCOUNT_THRESHOLD: usize = 2_000_000;
 
 /// Storage for per-information-set cumulative regrets and strategy sums.
@@ -204,20 +207,34 @@ impl InfoSetStore {
                 *r *= negative_discount;
             }
         };
-        if self.regrets.len() >= PARALLEL_DISCOUNT_THRESHOLD {
-            self.regrets.par_iter_mut().for_each(apply);
-        } else {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if self.regrets.len() >= PARALLEL_DISCOUNT_THRESHOLD {
+                self.regrets.par_iter_mut().for_each(apply);
+            } else {
+                self.regrets.iter_mut().for_each(apply);
+            }
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
             self.regrets.iter_mut().for_each(apply);
         }
     }
 
     /// DCFR: apply a discount factor to every strategy sum in one pass.
     pub fn discount_strategy_sum_all(&mut self, discount: f32) {
-        if self.strategy_sum.len() >= PARALLEL_DISCOUNT_THRESHOLD {
-            self.strategy_sum
-                .par_iter_mut()
-                .for_each(|s| *s *= discount);
-        } else {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if self.strategy_sum.len() >= PARALLEL_DISCOUNT_THRESHOLD {
+                self.strategy_sum
+                    .par_iter_mut()
+                    .for_each(|s| *s *= discount);
+            } else {
+                self.strategy_sum.iter_mut().for_each(|s| *s *= discount);
+            }
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
             self.strategy_sum.iter_mut().for_each(|s| *s *= discount);
         }
     }

--- a/src/solver/vector_api.rs
+++ b/src/solver/vector_api.rs
@@ -14,9 +14,14 @@
 //! - Turn subgame (4-card board) — uses
 //!   [`crate::solver::vector_postflop::build_vector_turn_tree`], which
 //!   enumerates the 48 possible river cards as chance children.
+//! - Flop subgame (3-card board) — uses
+//!   [`crate::solver::vector_postflop::build_vector_flop_tree`], which
+//!   enumerates the 49 possible turn cards and 48 possible river cards
+//!   under two nested chance layers. Expect memory/time costs that grow
+//!   with bet-config fanout; keep bet sizings lean for flop solves.
 //!
-//! Flop and earlier streets need additional chance-node layers and aren't
-//! yet covered by the vector builders. Callers receive
+//! Preflop (2-card hole selection at the root, no board) is not yet
+//! covered by the vector builders. Callers receive
 //! [`VectorSolveError::UnsupportedStreet`] in that case.
 //!
 //! ## Strategy aggregation
@@ -34,14 +39,17 @@ use crate::solver::range::HandRange;
 use crate::solver::showdown::N_COMBOS;
 use crate::solver::vector_cfr::{VectorCfrSolver, VectorNode};
 use crate::solver::vector_exploitability::compute_vector_exploitability;
-use crate::solver::vector_postflop::{build_vector_river_tree, build_vector_turn_tree};
+use crate::solver::vector_postflop::{
+    build_vector_flop_tree, build_vector_river_tree, build_vector_turn_tree,
+};
 
 /// Errors from the vector-CFR convenience API.
 #[derive(Debug, thiserror::Error)]
 pub enum VectorSolveError {
-    /// The board size isn't yet supported by the vector builder. Only river
-    /// (5 cards) and turn (4 cards) are wired up.
-    #[error("unsupported street: vector CFR currently supports turn (4) and river (5) boards, got {0} cards")]
+    /// The board size isn't yet supported by the vector builder. Flop
+    /// (3 cards), turn (4 cards) and river (5 cards) are wired up;
+    /// preflop (0 cards) is not.
+    #[error("unsupported street: vector CFR currently supports flop (3), turn (4) and river (5) boards, got {0} cards")]
     UnsupportedStreet(usize),
 }
 
@@ -119,6 +127,15 @@ pub fn solve_vector(cfg: VectorSolverConfig) -> Result<VectorSolverOutput, Vecto
                 cfg.bet_config.clone(),
             )
         }
+        3 => {
+            let board: [Card; 3] = [cfg.board[0], cfg.board[1], cfg.board[2]];
+            build_vector_flop_tree(
+                board,
+                cfg.starting_pot,
+                cfg.effective_stack,
+                cfg.bet_config.clone(),
+            )
+        }
         n => return Err(VectorSolveError::UnsupportedStreet(n)),
     };
 
@@ -139,7 +156,7 @@ pub fn solve_vector(cfg: VectorSolverConfig) -> Result<VectorSolverOutput, Vecto
 
     let exploitability = compute_vector_exploitability(
         &solver.tree,
-        &solver.store,
+        &solver.store(),
         &solver.starting_reach[0],
         &solver.starting_reach[1],
         ante,
@@ -238,7 +255,7 @@ fn aggregate_strategy(solver: &VectorCfrSolver) -> Vec<VectorInfoSetStrategy> {
         }
         let mut strat_buf = vec![0.0f32; n_actions * N_COMBOS];
         solver
-            .store
+            .store()
             .average_strategy_into(idx as u32, &mut strat_buf);
 
         // Sum across combos. Layout is combo-major: strat_buf[combo *
@@ -413,13 +430,9 @@ mod tests {
     }
 
     #[test]
-    fn solve_vector_rejects_flop() {
+    fn solve_vector_rejects_preflop() {
         let cfg = VectorSolverConfig {
-            board: vec![
-                Card::new(Rank::Ace, Suit::Spades),
-                Card::new(Rank::King, Suit::Hearts),
-                Card::new(Rank::Queen, Suit::Diamonds),
-            ],
+            board: vec![],
             range_oop: HandRange::full(),
             range_ip: HandRange::full(),
             starting_pot: 100.0,
@@ -429,6 +442,47 @@ mod tests {
             ante: 0.0,
         };
         let err = solve_vector(cfg).unwrap_err();
-        assert!(matches!(err, VectorSolveError::UnsupportedStreet(3)));
+        assert!(matches!(err, VectorSolveError::UnsupportedStreet(0)));
+    }
+
+    #[test]
+    fn solve_vector_flop_builds_tree() {
+        // Minimal config: 1 bet per street, no raises. Runs a tiny number
+        // of iterations to keep the test fast but still exercise the flop
+        // builder end-to-end.
+        let cfg = VectorSolverConfig {
+            board: vec![
+                Card::new(Rank::Ace, Suit::Spades),
+                Card::new(Rank::King, Suit::Hearts),
+                Card::new(Rank::Queen, Suit::Diamonds),
+            ],
+            range_oop: HandRange::full(),
+            range_ip: HandRange::full(),
+            starting_pot: 20.0,
+            effective_stack: 200.0,
+            bet_config: BetSizingConfig {
+                flop_bets: vec![1.0],
+                flop_raises: vec![],
+                turn_bets: vec![1.0],
+                turn_raises: vec![],
+                river_bets: vec![1.0],
+                river_raises: vec![],
+                always_allow_allin: false,
+                max_raises_per_street: 0,
+            },
+            cfr_config: SolverConfig {
+                algorithm: CfrAlgorithm::CfrPlus,
+                iterations: 1,
+                ..Default::default()
+            },
+            ante: 0.0,
+        };
+        let out = solve_vector(cfg).expect("flop solve should succeed");
+        assert!(out.game_value.is_finite());
+        assert!(
+            out.num_info_sets > 10,
+            "flop tree should have many info sets, got {}",
+            out.num_info_sets
+        );
     }
 }

--- a/src/solver/vector_cfr.rs
+++ b/src/solver/vector_cfr.rs
@@ -37,11 +37,32 @@
 //! analogue of the scalar solver's game-value output. Currently this is
 //! Σᵢ reach_p0[i] · v_p0[i], the unweighted sum across combos; callers
 //! with unit-weight starting ranges get a direct chip-EV number.
+//!
+//! ## Parallelism
+//!
+//! On non-WASM targets, chance-node children are traversed in parallel via
+//! [`rayon`]. Info-set indices are disjoint across chance children (the
+//! tree builders inject a per-card history separator, so distinct chance
+//! children never share an info-set), so writes to
+//! [`VectorInfoSetStore`] happen at disjoint slots. The store is still
+//! wrapped in a [`std::sync::Mutex`] to satisfy the borrow checker;
+//! contention is low in practice because each decision node only locks
+//! briefly to read its current strategy and (for the traversing player)
+//! commit the regret/strategy update.
+//!
+//! WASM builds keep the sequential traversal — the browser runs each
+//! solve in a single Web Worker thread, so the lock is never contended
+//! and rayon is excluded to keep the bundle small.
+
+use std::sync::Mutex;
 
 use crate::solver::action::Action;
 use crate::solver::cfr::{CfrAlgorithm, SolverConfig};
 use crate::solver::showdown::{ShowdownRanker, N_COMBOS};
 use crate::solver::vector_info_set::VectorInfoSetStore;
+
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
 
 /// Per-combo coefficient of 1.0 used as the "opponent reach" factor in
 /// vector-CFR regret updates. Terminal evaluators integrate opponent reach
@@ -122,9 +143,13 @@ pub struct VectorGameTree {
 
 /// Vector CFR solver. Analogous to [`crate::solver::cfr::CfrSolver`] but
 /// keeps per-combo regrets and strategy sums.
+///
+/// The store is wrapped in a [`Mutex`] so the traversal can parallelise
+/// chance-node children across rayon worker threads. Most read paths use
+/// [`VectorCfrSolver::store`] to acquire a guarded reference.
 pub struct VectorCfrSolver {
     pub tree: VectorGameTree,
-    pub store: VectorInfoSetStore,
+    pub store: Mutex<VectorInfoSetStore>,
     pub config: SolverConfig,
     /// Per-combo starting reach for each player (e.g. the normalised opening
     /// range). Carried down the tree along with the strategy-scaled updates.
@@ -143,10 +168,17 @@ impl VectorCfrSolver {
         let store = VectorInfoSetStore::new(&tree.actions_per_info_set);
         Self {
             tree,
-            store,
+            store: Mutex::new(store),
             config,
             starting_reach: [starting_reach_p0, starting_reach_p1],
         }
+    }
+
+    /// Acquire a lock on the info-set store. Read-only callers (strategy
+    /// readback, exploitability) should hold the guard only as long as
+    /// needed.
+    pub fn store(&self) -> std::sync::MutexGuard<'_, VectorInfoSetStore> {
+        self.store.lock().expect("vector store mutex poisoned")
     }
 
     /// Run one CFR iteration (two traversals, one per traversing player).
@@ -160,7 +192,7 @@ impl VectorCfrSolver {
 
         let v0 = vector_cfr_traverse(
             &self.tree,
-            &mut self.store,
+            &self.store,
             use_cfr_plus,
             self.tree.root,
             &reach_p0,
@@ -169,7 +201,7 @@ impl VectorCfrSolver {
         );
         let _v1 = vector_cfr_traverse(
             &self.tree,
-            &mut self.store,
+            &self.store,
             use_cfr_plus,
             self.tree.root,
             &reach_p0,
@@ -201,9 +233,16 @@ impl VectorCfrSolver {
 /// Mirrors the scalar traversal's recursion structure. The `_use_cfr_plus`
 /// flag is threaded through as a single bool so the traversal doesn't have
 /// to re-read it from the solver each call.
+///
+/// The store is passed as `&Mutex<VectorInfoSetStore>` so chance-node
+/// children can be traversed in parallel on non-WASM targets. The lock is
+/// only held briefly at decision nodes — once to read current strategy,
+/// once more (at the traversing player's nodes) to commit the regret and
+/// strategy-sum updates. Info-set indices are disjoint across chance
+/// children by construction, so contention is low in practice.
 fn vector_cfr_traverse(
     tree: &VectorGameTree,
-    store: &mut VectorInfoSetStore,
+    store: &Mutex<VectorInfoSetStore>,
     use_cfr_plus: bool,
     node_idx: VectorNodeIndex,
     reach_p0: &[f32; N_COMBOS],
@@ -256,20 +295,50 @@ fn vector_cfr_traverse(
             // For each dealt card `c`, zero out reach for combos that
             // contain `c` (they can't be held after the deal) before
             // recursing into the child subtree for that card.
+            //
+            // On non-WASM targets, children are traversed in parallel via
+            // rayon. The traversals are independent (disjoint info-set
+            // writes) so contention on the store mutex is low.
             let weight = 1.0 / children.len() as f32;
+
+            #[cfg(not(target_arch = "wasm32"))]
+            let child_evs: Vec<Box<[f32; N_COMBOS]>> = children
+                .par_iter()
+                .map(|&(card, child)| {
+                    let new_reach_p0 = zero_reach_blocked_by_card(reach_p0, card);
+                    let new_reach_p1 = zero_reach_blocked_by_card(reach_p1, card);
+                    vector_cfr_traverse(
+                        tree,
+                        store,
+                        use_cfr_plus,
+                        child,
+                        &new_reach_p0,
+                        &new_reach_p1,
+                        traversing_player,
+                    )
+                })
+                .collect();
+
+            #[cfg(target_arch = "wasm32")]
+            let child_evs: Vec<Box<[f32; N_COMBOS]>> = children
+                .iter()
+                .map(|&(card, child)| {
+                    let new_reach_p0 = zero_reach_blocked_by_card(reach_p0, card);
+                    let new_reach_p1 = zero_reach_blocked_by_card(reach_p1, card);
+                    vector_cfr_traverse(
+                        tree,
+                        store,
+                        use_cfr_plus,
+                        child,
+                        &new_reach_p0,
+                        &new_reach_p1,
+                        traversing_player,
+                    )
+                })
+                .collect();
+
             let mut ev = Box::new([0.0f32; N_COMBOS]);
-            for &(card, child) in children {
-                let new_reach_p0 = zero_reach_blocked_by_card(reach_p0, card);
-                let new_reach_p1 = zero_reach_blocked_by_card(reach_p1, card);
-                let child_v = vector_cfr_traverse(
-                    tree,
-                    store,
-                    use_cfr_plus,
-                    child,
-                    &new_reach_p0,
-                    &new_reach_p1,
-                    traversing_player,
-                );
+            for child_v in &child_evs {
                 for (slot, v) in ev.iter_mut().zip(child_v.iter()) {
                     *slot += weight * *v;
                 }
@@ -287,8 +356,13 @@ fn vector_cfr_traverse(
             let n_actions = children.len();
 
             // Regret-match the current strategy for every combo in one shot.
+            // Acquire the store lock only long enough to read the regret
+            // slab — the recursion into children must not hold the lock.
             let mut strategy = vec![0.0f32; n_actions * N_COMBOS];
-            store.current_strategy_into(info_set_idx, &mut strategy);
+            {
+                let guard = store.lock().expect("vector store mutex poisoned");
+                guard.current_strategy_into(info_set_idx, &mut strategy);
+            }
 
             // Per-action per-combo values from recursion.
             let mut action_values = vec![0.0f32; n_actions * N_COMBOS];
@@ -349,8 +423,8 @@ fn vector_cfr_traverse(
             // per-combo reach.
             if player == traversing_player {
                 let my_reach = if player == 0 { reach_p0 } else { reach_p1 };
-
-                store.update_regrets_and_strategy(
+                let mut guard = store.lock().expect("vector store mutex poisoned");
+                guard.update_regrets_and_strategy(
                     info_set_idx,
                     &action_values,
                     node_value.as_ref(),
@@ -483,12 +557,12 @@ mod tests {
     fn showdown_terminal_returns_scaled_ev() {
         let tree = tiny_tree(10.0, 0.0);
         let store_input: Vec<u8> = tree.actions_per_info_set.clone();
-        let mut store = VectorInfoSetStore::new(&store_input);
+        let store = Mutex::new(VectorInfoSetStore::new(&store_input));
         let r0 = unit_reach(&tree.rankers[0]);
         let r1 = unit_reach(&tree.rankers[0]);
 
         // Call the showdown node directly.
-        let v = vector_cfr_traverse(&tree, &mut store, true, 0, &r0, &r1, 0);
+        let v = vector_cfr_traverse(&tree, &store, true, 0, &r0, &r1, 0);
 
         // Must match ranker.ev_vs_opponent(r1) * 10.0 on every unblocked combo.
         let ref_ev = tree.rankers[0].ev_vs_opponent(&r1);
@@ -506,14 +580,14 @@ mod tests {
     fn fold_terminal_sign_matches_winner() {
         // P1 wins fold of pot 4.0.
         let tree = tiny_tree(0.0, 4.0);
-        let mut store = VectorInfoSetStore::new(&tree.actions_per_info_set);
+        let store = Mutex::new(VectorInfoSetStore::new(&tree.actions_per_info_set));
         let r0 = unit_reach(&tree.rankers[0]);
         let r1 = unit_reach(&tree.rankers[0]);
 
         // Traversing = P0 (the loser): value should be -4 * compat_sum.
-        let v0 = vector_cfr_traverse(&tree, &mut store, true, 1, &r0, &r1, 0);
+        let v0 = vector_cfr_traverse(&tree, &store, true, 1, &r0, &r1, 0);
         // Traversing = P1 (the winner): value should be +4 * compat_sum.
-        let v1 = vector_cfr_traverse(&tree, &mut store, true, 1, &r0, &r1, 1);
+        let v1 = vector_cfr_traverse(&tree, &store, true, 1, &r0, &r1, 1);
 
         for i in 0..N_COMBOS {
             if tree.rankers[0].is_blocked(i as u16) {
@@ -600,9 +674,9 @@ mod tests {
             actions_per_info_set: vec![],
             rankers: vec![ranker],
         };
-        let mut store = VectorInfoSetStore::new(&[]);
+        let store = Mutex::new(VectorInfoSetStore::new(&[]));
 
-        let v = vector_cfr_traverse(&tree, &mut store, true, 2, &r0, &r1, 0);
+        let v = vector_cfr_traverse(&tree, &store, true, 2, &r0, &r1, 0);
 
         // Independent reference computation: for each child, zero combos
         // blocked by its dealt card, compute ev, then average.
@@ -669,15 +743,16 @@ mod tests {
             actions_per_info_set: vec![2],
             rankers: vec![ranker],
         };
-        let mut store = VectorInfoSetStore::new(&tree.actions_per_info_set);
+        let store = Mutex::new(VectorInfoSetStore::new(&tree.actions_per_info_set));
 
         // Uniform start → each action is 0.5. Node value for combo aa:
         // 0.5 * (+5) + 0.5 * (-2) = 1.5.
         // Regret for showdown action = +5 - 1.5 = +3.5 > 0.
         // Regret for fold action   = -2 - 1.5 = -3.5 (clipped to 0 by CFR+).
-        let _ = vector_cfr_traverse(&tree, &mut store, true, 2, &r0, &r1, 0);
+        let _ = vector_cfr_traverse(&tree, &store, true, 2, &r0, &r1, 0);
 
         // After update, regrets at combo aa are [3.5, 0.0]. Read them back.
+        let store = store.into_inner().unwrap();
         let regrets = store.regrets_of(0);
         let base = aa * 2;
         assert!(

--- a/src/solver/vector_exploitability.rs
+++ b/src/solver/vector_exploitability.rs
@@ -35,6 +35,9 @@ use crate::solver::vector_cfr::{
 };
 use crate::solver::vector_info_set::VectorInfoSetStore;
 
+#[cfg(not(target_arch = "wasm32"))]
+use rayon::prelude::*;
+
 /// Exploitability of the current average strategy in milli-ante per hand.
 ///
 /// `ante` is the normalisation unit (typically the big blind, or
@@ -128,11 +131,30 @@ fn vector_br_traverse(
         }
 
         VectorNode::Chance { children } => {
+            // Parallelise over dealt cards on native; the store is read-only
+            // in this traversal so no synchronisation is needed.
             let weight = 1.0 / children.len() as f32;
+
+            #[cfg(not(target_arch = "wasm32"))]
+            let child_evs: Vec<Box<[f32; N_COMBOS]>> = children
+                .par_iter()
+                .map(|&(card, child)| {
+                    let new_opp = zero_reach_blocked_by_card(opp_reach, card);
+                    vector_br_traverse(tree, store, br_player, child, &new_opp)
+                })
+                .collect();
+
+            #[cfg(target_arch = "wasm32")]
+            let child_evs: Vec<Box<[f32; N_COMBOS]>> = children
+                .iter()
+                .map(|&(card, child)| {
+                    let new_opp = zero_reach_blocked_by_card(opp_reach, card);
+                    vector_br_traverse(tree, store, br_player, child, &new_opp)
+                })
+                .collect();
+
             let mut ev = Box::new([0.0f32; N_COMBOS]);
-            for &(card, child) in children {
-                let new_opp = zero_reach_blocked_by_card(opp_reach, card);
-                let child_ev = vector_br_traverse(tree, store, br_player, child, &new_opp);
+            for child_ev in &child_evs {
                 for (slot, v) in ev.iter_mut().zip(child_ev.iter()) {
                     *slot += weight * v;
                 }
@@ -276,7 +298,7 @@ mod tests {
 
         let exp = compute_vector_exploitability(
             &solver.tree,
-            &solver.store,
+            &solver.store(),
             &solver.starting_reach[0],
             &solver.starting_reach[1],
             1.0,
@@ -319,7 +341,7 @@ mod tests {
         s10.solve();
         let exp10 = compute_vector_exploitability(
             &s10.tree,
-            &s10.store,
+            &s10.store(),
             &s10.starting_reach[0],
             &s10.starting_reach[1],
             1.0,
@@ -340,7 +362,7 @@ mod tests {
         s500.solve();
         let exp500 = compute_vector_exploitability(
             &s500.tree,
-            &s500.store,
+            &s500.store(),
             &s500.starting_reach[0],
             &s500.starting_reach[1],
             1.0,
@@ -390,7 +412,7 @@ mod tests {
         // 1000 CFR+ iterations on a simple river should be well under 100 mbb.
         let exp = compute_vector_exploitability(
             &solver.tree,
-            &solver.store,
+            &solver.store(),
             &solver.starting_reach[0],
             &solver.starting_reach[1],
             50.0,

--- a/src/solver/vector_postflop.rs
+++ b/src/solver/vector_postflop.rs
@@ -587,6 +587,344 @@ impl VectorTurnBuilder {
     }
 }
 
+/// Build a vector-form game tree for a flop subgame: three streets of action
+/// with two chance-node layers (deal turn, then deal river).
+///
+/// `flop_board` is the 3-card flop. The builder enumerates every possible
+/// (turn_card, river_card) runout, pre-computes one [`ShowdownRanker`] per
+/// resulting 5-card final board, and wires them under two nested chance
+/// layers. For a fresh flop with 49 remaining cards, that's
+/// `49 * 48 = 2_352` final boards — this is the authoritative tree shape
+/// that a real flop solver must traverse; callers should keep bet-sizing
+/// configs minimal (1 size per street, no raises) to stay within workable
+/// memory budgets.
+pub fn build_vector_flop_tree(
+    flop_board: [Card; 3],
+    starting_pot: f32,
+    effective_stack: f32,
+    bet_config: BetSizingConfig,
+) -> VectorGameTree {
+    let known: [bool; 52] = {
+        let mut k = [false; 52];
+        for c in flop_board.iter() {
+            k[c.index() as usize] = true;
+        }
+        k
+    };
+    // (turn_card, river_card) → ranker index. Boxed to keep the ~5 KB
+    // lookup off the stack.
+    let mut board_ranker_idx: Box<[[Option<u16>; 52]; 52]> = Box::new([[None; 52]; 52]);
+    let mut rankers: Vec<ShowdownRanker> = Vec::with_capacity(49 * 48);
+    for turn in 0..52u8 {
+        if known[turn as usize] {
+            continue;
+        }
+        for river in 0..52u8 {
+            if known[river as usize] || river == turn {
+                continue;
+            }
+            let final_board = [
+                flop_board[0],
+                flop_board[1],
+                flop_board[2],
+                Card::from_index(turn),
+                Card::from_index(river),
+            ];
+            board_ranker_idx[turn as usize][river as usize] = Some(rankers.len() as u16);
+            rankers.push(ShowdownRanker::new(&final_board));
+        }
+    }
+
+    let mut builder = VectorFlopBuilder {
+        nodes: Vec::new(),
+        info_set_map: HashMap::new(),
+        next_info_set_idx: 0,
+        actions_per_info_set: Vec::new(),
+        bet_config,
+        board_ranker_idx,
+        flop_blocked: known,
+    };
+
+    let initial_contrib = starting_pot / 2.0;
+    let state = FlopBuildState {
+        pot_contributions: [initial_contrib, initial_contrib],
+        stacks: [effective_stack, effective_stack],
+        action_history: Vec::new(),
+        raises_this_street: 0,
+        street: 0,
+        turn_card: 0,
+        ranker_idx: 0,
+    };
+
+    let root = builder.build_action_node(0, &state);
+
+    VectorGameTree {
+        nodes: builder.nodes,
+        root,
+        actions_per_info_set: builder.actions_per_info_set,
+        rankers,
+    }
+}
+
+struct VectorFlopBuilder {
+    nodes: Vec<VectorNode>,
+    info_set_map: HashMap<InfoSetKey, u32>,
+    next_info_set_idx: u32,
+    actions_per_info_set: Vec<u8>,
+    bet_config: BetSizingConfig,
+    /// Ranker index for each `(turn_card, river_card)` pair. Entries for
+    /// cards already on the flop or identical turn/river pairs are `None`.
+    board_ranker_idx: Box<[[Option<u16>; 52]; 52]>,
+    /// Which card indices are on the flop (dead cards for chance deals).
+    flop_blocked: [bool; 52],
+}
+
+/// Build state for the flop tree. `street` is 0=flop, 1=turn, 2=river.
+/// `turn_card` is meaningful once street ≥ 1 (it identifies the dealt turn
+/// card and indexes into `board_ranker_idx`). `ranker_idx` is meaningful at
+/// river terminals (street == 2) and is selected by `(turn_card, river_card)`
+/// at the river chance-branch step.
+#[derive(Clone, Debug)]
+struct FlopBuildState {
+    pot_contributions: [f32; 2],
+    stacks: [f32; 2],
+    action_history: Vec<u8>,
+    raises_this_street: u8,
+    street: u8,
+    turn_card: u8,
+    ranker_idx: u16,
+}
+
+impl VectorFlopBuilder {
+    fn push_node(&mut self, node: VectorNode) -> VectorNodeIndex {
+        let idx = self.nodes.len() as VectorNodeIndex;
+        self.nodes.push(node);
+        idx
+    }
+
+    fn get_or_create_info_set(&mut self, player: u8, history: &[u8], n_actions: u8) -> u32 {
+        let key = InfoSetKey {
+            player,
+            history: history.to_vec(),
+        };
+        if let Some(&idx) = self.info_set_map.get(&key) {
+            return idx;
+        }
+        let idx = self.next_info_set_idx;
+        self.info_set_map.insert(key, idx);
+        self.next_info_set_idx += 1;
+        self.actions_per_info_set.push(n_actions);
+        idx
+    }
+
+    fn build_action_node(&mut self, player: u8, state: &FlopBuildState) -> VectorNodeIndex {
+        let pot = state.pot_contributions[0] + state.pot_contributions[1];
+        let to_call =
+            state.pot_contributions[1 - player as usize] - state.pot_contributions[player as usize];
+        let stack = state.stacks[player as usize];
+
+        let (actions, action_codes) = self.enumerate_actions(state, pot, to_call, stack);
+        let n_actions = actions.len() as u8;
+
+        let info_set_idx = self.get_or_create_info_set(player, &state.action_history, n_actions);
+
+        let mut children: Vec<VectorNodeIndex> = Vec::with_capacity(actions.len());
+        for (action, code) in actions.iter().zip(action_codes.iter()) {
+            let child = self.build_action_child(player, state, action, *code);
+            children.push(child);
+        }
+
+        self.push_node(VectorNode::Decision {
+            player,
+            actions,
+            children,
+            info_set_idx,
+        })
+    }
+
+    fn enumerate_actions(
+        &self,
+        state: &FlopBuildState,
+        pot: f32,
+        to_call: f32,
+        stack: f32,
+    ) -> (Vec<Action>, Vec<u8>) {
+        let mut actions = Vec::new();
+        let mut codes = Vec::new();
+
+        let (bet_sizes, raise_sizes): (&[f64], &[f64]) = match state.street {
+            0 => (&self.bet_config.flop_bets, &self.bet_config.flop_raises),
+            1 => (&self.bet_config.turn_bets, &self.bet_config.turn_raises),
+            _ => (&self.bet_config.river_bets, &self.bet_config.river_raises),
+        };
+
+        if to_call > 0.0 {
+            actions.push(Action::Fold);
+            codes.push(0);
+            actions.push(Action::Call);
+            codes.push(1);
+
+            if state.raises_this_street < self.bet_config.max_raises_per_street {
+                for &size_fraction in raise_sizes {
+                    let raise_amount = (pot + to_call) * size_fraction as f32;
+                    let total_to_put_in = to_call + raise_amount;
+                    if total_to_put_in < stack {
+                        actions.push(Action::bet_from_fraction(size_fraction));
+                        codes.push(2 + (size_fraction * 100.0) as u8);
+                    }
+                }
+                if self.bet_config.always_allow_allin && stack > to_call {
+                    actions.push(Action::AllIn);
+                    codes.push(255);
+                }
+            }
+        } else {
+            actions.push(Action::Check);
+            codes.push(0);
+
+            for &size_fraction in bet_sizes {
+                let bet_amount = pot * size_fraction as f32;
+                if bet_amount < stack {
+                    actions.push(Action::bet_from_fraction(size_fraction));
+                    codes.push(1 + (size_fraction * 100.0) as u8);
+                }
+            }
+            if self.bet_config.always_allow_allin && stack > 0.0 {
+                actions.push(Action::AllIn);
+                codes.push(255);
+            }
+        }
+
+        (actions, codes)
+    }
+
+    fn build_action_child(
+        &mut self,
+        player: u8,
+        state: &FlopBuildState,
+        action: &Action,
+        action_code: u8,
+    ) -> VectorNodeIndex {
+        let opponent = 1 - player;
+        let pot = state.pot_contributions[0] + state.pot_contributions[1];
+        let to_call =
+            state.pot_contributions[opponent as usize] - state.pot_contributions[player as usize];
+
+        let mut new_state = state.clone();
+        new_state.action_history.push(action_code);
+
+        match action {
+            Action::Fold => {
+                let pot_won = state.pot_contributions[player as usize];
+                self.push_node(VectorNode::Fold {
+                    winner: opponent,
+                    pot_won,
+                })
+            }
+            Action::Check => {
+                if player == 1 {
+                    self.end_of_street(&new_state)
+                } else {
+                    self.build_action_node(opponent, &new_state)
+                }
+            }
+            Action::Call => {
+                new_state.pot_contributions[player as usize] += to_call;
+                new_state.stacks[player as usize] -= to_call;
+                self.end_of_street(&new_state)
+            }
+            Action::Bet(bp) => {
+                let size_fraction = *bp as f32 / 10000.0;
+                let amount = if to_call > 0.0 {
+                    let raise_amount = (pot + to_call) * size_fraction;
+                    to_call + raise_amount
+                } else {
+                    pot * size_fraction
+                };
+                let amount = amount.min(new_state.stacks[player as usize]);
+                new_state.pot_contributions[player as usize] += amount;
+                new_state.stacks[player as usize] -= amount;
+                new_state.raises_this_street += 1;
+                self.build_action_node(opponent, &new_state)
+            }
+            Action::AllIn => {
+                let amount = new_state.stacks[player as usize];
+                new_state.pot_contributions[player as usize] += amount;
+                new_state.stacks[player as usize] = 0.0;
+                new_state.raises_this_street += 1;
+                if new_state.stacks[opponent as usize] == 0.0 {
+                    self.end_of_street(&new_state)
+                } else {
+                    self.build_action_node(opponent, &new_state)
+                }
+            }
+        }
+    }
+
+    /// End-of-street transition. On the flop, deal the turn via a chance
+    /// node. On the turn, deal the river via a chance node (each river
+    /// subtree uses the ranker for the final `(turn_card, river_card)`
+    /// board). On the river, go to showdown.
+    fn end_of_street(&mut self, state: &FlopBuildState) -> VectorNodeIndex {
+        match state.street {
+            2 => self.push_showdown(state),
+            1 => {
+                // Deal the river. For each river card compatible with the
+                // current flop + turn, build a river-action subtree.
+                let mut children: Vec<(u8, VectorNodeIndex)> = Vec::with_capacity(48);
+                for card_idx in 0..52u8 {
+                    if self.flop_blocked[card_idx as usize] || card_idx == state.turn_card {
+                        continue;
+                    }
+                    let ranker_idx =
+                        match self.board_ranker_idx[state.turn_card as usize][card_idx as usize] {
+                            Some(idx) => idx,
+                            None => continue,
+                        };
+                    let mut next = state.clone();
+                    next.street = 2;
+                    next.raises_this_street = 0;
+                    next.ranker_idx = ranker_idx;
+                    next.action_history.push(200 + card_idx);
+                    let subtree = self.build_action_node(0, &next);
+                    children.push((card_idx, subtree));
+                }
+                self.push_node(VectorNode::Chance { children })
+            }
+            _ => {
+                // street == 0: deal the turn.
+                let mut children: Vec<(u8, VectorNodeIndex)> = Vec::with_capacity(49);
+                for card_idx in 0..52u8 {
+                    if self.flop_blocked[card_idx as usize] {
+                        continue;
+                    }
+                    let mut next = state.clone();
+                    next.street = 1;
+                    next.raises_this_street = 0;
+                    next.turn_card = card_idx;
+                    next.action_history.push(200 + card_idx);
+                    let subtree = self.build_action_node(0, &next);
+                    children.push((card_idx, subtree));
+                }
+                self.push_node(VectorNode::Chance { children })
+            }
+        }
+    }
+
+    fn push_showdown(&mut self, state: &FlopBuildState) -> VectorNodeIndex {
+        debug_assert!(
+            (state.pot_contributions[0] - state.pot_contributions[1]).abs() < 1e-3,
+            "showdown reached with mismatched contributions: {:?}",
+            state.pot_contributions
+        );
+        let half_pot = state.pot_contributions[0];
+        self.push_node(VectorNode::Showdown {
+            half_pot,
+            ranker_idx: state.ranker_idx,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -779,7 +1117,7 @@ mod tests {
         // history for player 0 — it's the first one created, so == 0.
         let n_actions = solver.tree.actions_per_info_set[0] as usize;
         let mut avg = vec![0.0f32; n_actions * N_COMBOS];
-        solver.store.average_strategy_into(0, &mut avg);
+        solver.store().average_strategy_into(0, &mut avg);
         let aa_strat: &[f32] = &avg[aa * n_actions..(aa + 1) * n_actions];
 
         // Action 0 is `Check` per the simple river config. Bet actions
@@ -939,5 +1277,148 @@ mod tests {
             n_info_sets >= 2,
             "expected at least 2 info sets, got {n_info_sets}"
         );
+    }
+
+    fn flop_board() -> [Card; 3] {
+        [
+            Card::new(Rank::Ace, Suit::Spades),
+            Card::new(Rank::King, Suit::Hearts),
+            Card::new(Rank::Queen, Suit::Diamonds),
+        ]
+    }
+
+    /// Minimal flop config. Flop tree is big (49 × 48 final boards) so we
+    /// keep sizings trivial — one bet per street, no raises, no all-ins.
+    fn minimal_flop_config() -> BetSizingConfig {
+        BetSizingConfig {
+            flop_bets: vec![1.0],
+            flop_raises: vec![],
+            turn_bets: vec![1.0],
+            turn_raises: vec![],
+            river_bets: vec![1.0],
+            river_raises: vec![],
+            always_allow_allin: false,
+            max_raises_per_street: 0,
+        }
+    }
+
+    #[test]
+    fn flop_tree_has_2352_final_boards() {
+        let tree = build_vector_flop_tree(flop_board(), 20.0, 200.0, minimal_flop_config());
+        // 49 remaining cards for the turn × 48 remaining for the river
+        // = 2_352 distinct final (5-card) boards.
+        assert_eq!(
+            tree.rankers.len(),
+            49 * 48,
+            "expected 49*48 rankers; got {}",
+            tree.rankers.len()
+        );
+    }
+
+    #[test]
+    fn flop_tree_has_two_chance_layers() {
+        let tree = build_vector_flop_tree(flop_board(), 20.0, 200.0, minimal_flop_config());
+        // Each chance node is either the turn-deal (49 children) or a
+        // river-deal (48 children). With min config, the flop tree ends
+        // the street fastest when both players check, so we should see
+        // ≥1 turn-dealing chance node and ≥1 river-dealing chance node.
+        let mut turn_chance = 0usize;
+        let mut river_chance = 0usize;
+        for node in &tree.nodes {
+            if let VectorNode::Chance { children } = node {
+                match children.len() {
+                    49 => turn_chance += 1,
+                    48 => river_chance += 1,
+                    other => panic!("unexpected chance-node fanout: {other}"),
+                }
+            }
+        }
+        assert!(
+            turn_chance >= 1,
+            "expected at least one turn chance node; got {turn_chance}"
+        );
+        assert!(
+            river_chance >= 1,
+            "expected at least one river chance node; got {river_chance}"
+        );
+    }
+
+    #[test]
+    fn flop_tree_root_is_p0_decision() {
+        let tree = build_vector_flop_tree(flop_board(), 20.0, 200.0, minimal_flop_config());
+        match &tree.nodes[tree.root as usize] {
+            VectorNode::Decision {
+                player, actions, ..
+            } => {
+                assert_eq!(*player, 0, "OOP (P0) acts first on the flop");
+                // Minimal config: Check + one Bet size.
+                assert_eq!(actions.len(), 2, "check + one bet");
+            }
+            other => panic!("root should be Decision, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn flop_tree_all_showdowns_have_valid_rankers() {
+        let tree = build_vector_flop_tree(flop_board(), 20.0, 200.0, minimal_flop_config());
+        let n_rankers = tree.rankers.len();
+        let mut seen = std::collections::HashSet::new();
+        for node in &tree.nodes {
+            if let VectorNode::Showdown { ranker_idx, .. } = node {
+                assert!(
+                    (*ranker_idx as usize) < n_rankers,
+                    "ranker_idx {ranker_idx} out of range (have {n_rankers} rankers)"
+                );
+                seen.insert(*ranker_idx);
+            }
+        }
+        // Every one of the 2_352 final boards should produce a showdown.
+        assert_eq!(
+            seen.len(),
+            n_rankers,
+            "every final board should be referenced by at least one showdown"
+        );
+    }
+
+    #[test]
+    fn flop_tree_solver_runs_one_iteration() {
+        let tree = build_vector_flop_tree(flop_board(), 20.0, 200.0, minimal_flop_config());
+        // Seed unit reach for every combo; block-by-card in the chance
+        // node traversal will zero out combos that share a card with the
+        // dealt turn/river.
+        let mut r0 = Box::new([0.0f32; N_COMBOS]);
+        let mut r1 = Box::new([0.0f32; N_COMBOS]);
+        for i in 0..N_COMBOS {
+            r0[i] = 1.0;
+            r1[i] = 1.0;
+        }
+        // Zero combos that contain any flop card — those can never be
+        // dealt from the remaining deck.
+        use crate::solver::range::HandRange;
+        for c in flop_board().iter() {
+            let card_idx = c.index() as usize;
+            for other in 0..52usize {
+                if other == card_idx {
+                    continue;
+                }
+                let (lo, hi) = if card_idx < other {
+                    (card_idx as u8, other as u8)
+                } else {
+                    (other as u8, card_idx as u8)
+                };
+                let combo = HandRange::combo_index(Card::from_index(lo), Card::from_index(hi));
+                r0[combo as usize] = 0.0;
+                r1[combo as usize] = 0.0;
+            }
+        }
+
+        let config = SolverConfig {
+            algorithm: CfrAlgorithm::CfrPlus,
+            iterations: 1,
+            ..Default::default()
+        };
+        let mut solver = VectorCfrSolver::new(tree, r0, r1, config);
+        let v = solver.run_iteration(0);
+        assert!(v.is_finite(), "flop iteration value should be finite: {v}");
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -11,6 +11,10 @@ use crate::cards::Card;
 use crate::eval::HandCategory;
 use crate::game::{GameState, GameVariant};
 use crate::sim::{run_simulation, SimConfig};
+use crate::solver::action::BetSizingConfig;
+use crate::solver::cfr::{CfrAlgorithm, SolverConfig};
+use crate::solver::range::HandRange;
+use crate::solver::vector_api::{solve_vector, VectorSolverConfig};
 
 // ── Panic hook ───────────────────────────────────────────────────────────────
 
@@ -113,6 +117,38 @@ pub fn validate_card(s: &str) -> bool {
     Card::from_str(s).is_ok()
 }
 
+// ── Vector CFR solver ────────────────────────────────────────────────────────
+
+/// Run the PIOSolver-style vector CFR on a postflop subgame.
+///
+/// **Input JSON:**
+/// ```json
+/// {
+///   "board": ["Ah", "Kd", "5c"],
+///   "range_oop": "22+,A2s+,KTs+",
+///   "range_ip":  "22+,ATs+,KJs+",
+///   "starting_pot": 10.0,
+///   "effective_stack": 100.0,
+///   "iterations": 500,
+///   "algorithm": "cfr_plus",
+///   "bet_config": { ...optional... }
+/// }
+/// ```
+///
+/// Board length must be 3 (flop), 4 (turn) or 5 (river). Ranges accept the
+/// same notation as [`HandRange::from_str`] (e.g. `"AA,KK,AKs"`); use
+/// `"all"` as a shortcut for the full 1326-combo range.
+///
+/// **Output JSON:** [`VectorSolveOutput`] on success, `{ "error": "..." }`
+/// on failure.
+#[wasm_bindgen]
+pub fn solve_postflop(input_json: &str) -> String {
+    match run_solve_postflop(input_json) {
+        Ok(out) => serde_json::to_string(&out).unwrap_or_else(|e| error_json(&e.to_string())),
+        Err(e) => error_json(&e),
+    }
+}
+
 // ── Internals ─────────────────────────────────────────────────────────────────
 
 fn run_calculate(input_json: &str) -> Result<SimOutput, String> {
@@ -194,4 +230,190 @@ fn error_json(msg: &str) -> String {
         error: msg.to_string(),
     })
     .unwrap_or_else(|_| r#"{"error":"serialization failed"}"#.to_string())
+}
+
+// ── Vector solver internals ─────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct SolveInput {
+    board: Vec<String>,
+    range_oop: String,
+    range_ip: String,
+    starting_pot: f32,
+    effective_stack: f32,
+    #[serde(default = "default_iterations")]
+    iterations: u32,
+    #[serde(default)]
+    algorithm: AlgorithmTag,
+    #[serde(default)]
+    bet_config: Option<BetConfigInput>,
+    #[serde(default)]
+    ante: Option<f32>,
+}
+
+fn default_iterations() -> u32 {
+    200
+}
+
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+enum AlgorithmTag {
+    #[default]
+    CfrPlus,
+    Dcfr,
+}
+
+impl From<AlgorithmTag> for CfrAlgorithm {
+    fn from(t: AlgorithmTag) -> Self {
+        match t {
+            AlgorithmTag::CfrPlus => CfrAlgorithm::CfrPlus,
+            AlgorithmTag::Dcfr => CfrAlgorithm::Dcfr,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct BetConfigInput {
+    #[serde(default)]
+    flop_bets: Option<Vec<f64>>,
+    #[serde(default)]
+    flop_raises: Option<Vec<f64>>,
+    #[serde(default)]
+    turn_bets: Option<Vec<f64>>,
+    #[serde(default)]
+    turn_raises: Option<Vec<f64>>,
+    #[serde(default)]
+    river_bets: Option<Vec<f64>>,
+    #[serde(default)]
+    river_raises: Option<Vec<f64>>,
+    #[serde(default)]
+    always_allow_allin: Option<bool>,
+    #[serde(default)]
+    max_raises_per_street: Option<u8>,
+}
+
+impl BetConfigInput {
+    fn into_config(self) -> BetSizingConfig {
+        let mut out = BetSizingConfig::default();
+        if let Some(v) = self.flop_bets {
+            out.flop_bets = v;
+        }
+        if let Some(v) = self.flop_raises {
+            out.flop_raises = v;
+        }
+        if let Some(v) = self.turn_bets {
+            out.turn_bets = v;
+        }
+        if let Some(v) = self.turn_raises {
+            out.turn_raises = v;
+        }
+        if let Some(v) = self.river_bets {
+            out.river_bets = v;
+        }
+        if let Some(v) = self.river_raises {
+            out.river_raises = v;
+        }
+        if let Some(v) = self.always_allow_allin {
+            out.always_allow_allin = v;
+        }
+        if let Some(v) = self.max_raises_per_street {
+            out.max_raises_per_street = v;
+        }
+        out
+    }
+}
+
+#[derive(Serialize)]
+struct InfoSetOut {
+    info_set_idx: u32,
+    player: u8,
+    actions: Vec<String>,
+    probs: Vec<f32>,
+    history_label: String,
+}
+
+#[derive(Serialize)]
+struct SolveOutput {
+    game_value: f64,
+    exploitability: f64,
+    num_info_sets: u32,
+    num_nodes: u32,
+    strategies: Vec<InfoSetOut>,
+}
+
+fn parse_range(s: &str) -> Result<HandRange, String> {
+    let trimmed = s.trim();
+    if trimmed.eq_ignore_ascii_case("all") || trimmed.is_empty() {
+        return Ok(HandRange::full());
+    }
+    HandRange::from_str(trimmed).map_err(|e| format!("invalid range '{}': {}", s, e))
+}
+
+fn run_solve_postflop(input_json: &str) -> Result<SolveOutput, String> {
+    let input: SolveInput =
+        serde_json::from_str(input_json).map_err(|e| format!("Invalid JSON: {}", e))?;
+
+    let board: Vec<Card> = input
+        .board
+        .iter()
+        .map(|s| Card::from_str(s).map_err(|e| format!("Invalid card '{}': {}", s, e)))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if !matches!(board.len(), 3..=5) {
+        return Err(format!(
+            "unsupported board length {}: expected 3 (flop), 4 (turn) or 5 (river)",
+            board.len()
+        ));
+    }
+
+    let range_oop = parse_range(&input.range_oop)?;
+    let range_ip = parse_range(&input.range_ip)?;
+
+    let bet_config = input
+        .bet_config
+        .map(|b| b.into_config())
+        .unwrap_or_default();
+
+    let cfr_config = SolverConfig {
+        algorithm: input.algorithm.into(),
+        iterations: input.iterations.max(1),
+        ..Default::default()
+    };
+
+    let ante = input
+        .ante
+        .filter(|&a| a > 0.0)
+        .unwrap_or(input.starting_pot / 2.0)
+        .max(1.0);
+
+    let cfg = VectorSolverConfig {
+        board,
+        range_oop,
+        range_ip,
+        starting_pot: input.starting_pot,
+        effective_stack: input.effective_stack,
+        bet_config,
+        cfr_config,
+        ante,
+    };
+
+    let out = solve_vector(cfg).map_err(|e| e.to_string())?;
+
+    Ok(SolveOutput {
+        game_value: out.game_value,
+        exploitability: out.exploitability,
+        num_info_sets: out.num_info_sets,
+        num_nodes: out.num_nodes,
+        strategies: out
+            .strategies
+            .into_iter()
+            .map(|s| InfoSetOut {
+                info_set_idx: s.info_set_idx,
+                player: s.player,
+                actions: s.actions.iter().map(|a| a.to_string()).collect(),
+                probs: s.probs,
+                history_label: s.history_label,
+            })
+            .collect(),
+    })
 }


### PR DESCRIPTION
Completes the four "Next steps" from the v0.4.0-alpha1 vector CFR PR.

## Summary

- **Flop vector builder** (`build_vector_flop_tree`) — two chance layers deal the turn then the river, producing 49×48 = 2352 final boards. Each showdown points at a precomputed `ShowdownRanker` for its 5-card board. Wired into `solve_vector` so flop-size boards now go through the same API as turn/river.
- **Scalar vs vector baseline bench** — `bench_river_full_range_vs_vector` runs the scalar CFR for `iters * 1326` iterations (one per combo) alongside the vector CFR for `iters` iterations, giving a direct per-combo comparison of the two implementations on equal workload.
- **Rayon-parallel chance nodes** — `VectorInfoSetStore` is wrapped in `std::sync::Mutex` so the recursion can hand the store to `par_iter` closures. Writes across chance children are disjoint by construction (tree builders inject per-card history separator bytes), so contention stays low: decision nodes only lock briefly to read the current strategy and commit the regret/strategy-sum update. `vector_exploitability`'s chance nodes also use `par_iter` (read-only, no lock). WASM builds keep the sequential traversal and exclude rayon.
- **WASM binding** — `solve_postflop(json)` accepts board, ranges, pot, stack, iterations, algorithm and an optional bet config, and returns game value, exploitability, tree size and aggregated per-info-set strategies. The `solver` module is now compiled for `wasm32` with rayon usage gated off in `info_set.rs`, `vector_cfr.rs` and `vector_exploitability.rs`.

## Test plan

- [x] `cargo test --lib` — 103 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy --target wasm32-unknown-unknown --lib -- -D warnings` — clean
- [x] Native `cargo check --all-targets` and WASM `cargo check --target wasm32-unknown-unknown --lib` both build
- [ ] End-to-end `solve_postflop` smoke test from the browser (requires `wasm-pack` + Vite dev server; not available in this environment)

https://claude.ai/code/session_011gXDs5AHGwE2ZFPyGmKaa5